### PR TITLE
Implementation update: Issue 1 for the DoubleLinkedSeq class

### DIFF
--- a/Data Structures with Java/Book Exercises/src/edu/bostonuniversity/collections/DoubleLinkedSeq.java
+++ b/Data Structures with Java/Book Exercises/src/edu/bostonuniversity/collections/DoubleLinkedSeq.java
@@ -236,8 +236,9 @@ public class DoubleLinkedSeq implements Cloneable {
         if (s1 == null) { throw new IllegalArgumentException("s1 is null."); }
         if (s2 == null) { throw new IllegalArgumentException("s2 is null."); }
 
-        DoubleLinkedSeq answer = s1.clone(); // Create a new sequence and...
-        answer.addAll(s2); // ...join the elements of s1 with s2
+        DoubleLinkedSeq answer = s1.clone(); // Clone the s1 sequence and...
+        DoubleLinkedSeq copyS2 = s2.clone(); // ...clone the s2 sequence and...
+        answer.addAll(copyS2); // ...join the two cloned sequences together.
         return answer;
     }
 

--- a/Data Structures with Java/Book Exercises/src/edu/bostonuniversity/collections/DoubleLinkedSeq.java
+++ b/Data Structures with Java/Book Exercises/src/edu/bostonuniversity/collections/DoubleLinkedSeq.java
@@ -13,7 +13,7 @@ import edu.bostonuniversity.nodes.DoubleNode;
  *   1. Beyond Integer.MAX_VALUE elements, the size method does not work.
  *
  * @author mlewis
- * @version Sep 23, 2019
+ * @version Sep 25, 2019
  *********************************************************************************************************************/
 
 public class DoubleLinkedSeq implements Cloneable {


### PR DESCRIPTION
Cloned the s2 sequence in the concatenation method. The clone of s2 is required because both s1 _and_ s2 should not change if the new concatenated sequence is updated.